### PR TITLE
feat: add per-user changeTicketType override UI and endpoint (#460)

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -124,6 +124,7 @@ class DefaultController extends AbstractController
             $data['behavior'] = [
                 'callTicketByService'  => $userBehavior->callTicketByService,
                 'callTicketOutOfOrder' => $userBehavior->callTicketOutOfOrder,
+                'changeTicketType'     => $userBehavior->changeTicketType,
             ];
 
             return $data;
@@ -579,6 +580,7 @@ class DefaultController extends AbstractController
             new UserBehaviorSettings(
                 callTicketByService: $data->callTicketByService,
                 callTicketOutOfOrder: $data->callTicketOutOfOrder,
+                changeTicketType: $data->changeTicketType,
             ),
         );
 

--- a/src/Dto/UpdateUsuarioBehaviorDto.php
+++ b/src/Dto/UpdateUsuarioBehaviorDto.php
@@ -18,6 +18,7 @@ final readonly class UpdateUsuarioBehaviorDto
     public function __construct(
         public ?bool $callTicketByService,
         public ?bool $callTicketOutOfOrder,
+        public ?bool $changeTicketType,
     ) {
     }
 }

--- a/src/Resources/public/js/script.js
+++ b/src/Resources/public/js/script.js
@@ -268,10 +268,7 @@
                 App.ajax({
                     url: App.url('/novosga.settings/usuario/') + usuario.id + '/behavior',
                     type: 'put',
-                    data: {
-                        callTicketByService: usuario.behavior.callTicketByService,
-                        callTicketOutOfOrder: usuario.behavior.callTicketOutOfOrder,
-                    }
+                    data: usuario.behavior
                 });
             },
         },

--- a/src/Resources/translations/NovosgaSettingsBundle.en.xlf
+++ b/src/Resources/translations/NovosgaSettingsBundle.en.xlf
@@ -121,6 +121,10 @@
         <target>Global default</target>
 
       </trans-unit>
+      <trans-unit id="21">
+        <source>settings.user.change_ticket_type</source>
+        <target>Change ticket type</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaSettingsBundle.en_US.xlf
+++ b/src/Resources/translations/NovosgaSettingsBundle.en_US.xlf
@@ -121,6 +121,10 @@
         <target>Global default</target>
 
       </trans-unit>
+      <trans-unit id="21">
+        <source>settings.user.change_ticket_type</source>
+        <target>Change ticket type</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaSettingsBundle.es.xlf
+++ b/src/Resources/translations/NovosgaSettingsBundle.es.xlf
@@ -121,6 +121,10 @@
         <target>Predeterminado global</target>
 
       </trans-unit>
+      <trans-unit id="21">
+        <source>settings.user.change_ticket_type</source>
+        <target>Cambiar tipo de atención</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaSettingsBundle.es_AR.xlf
+++ b/src/Resources/translations/NovosgaSettingsBundle.es_AR.xlf
@@ -121,6 +121,10 @@
         <target>Predeterminado global</target>
 
       </trans-unit>
+      <trans-unit id="21">
+        <source>settings.user.change_ticket_type</source>
+        <target>Cambiar tipo de atención</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaSettingsBundle.pt_BR.xlf
+++ b/src/Resources/translations/NovosgaSettingsBundle.pt_BR.xlf
@@ -98,6 +98,10 @@
         <source>settings.user.use_global</source>
         <target>Padrão global</target>
       </trans-unit>
+      <trans-unit id="21">
+        <source>settings.user.change_ticket_type</source>
+        <target>Alterar tipo de atendimento</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaSettingsBundle.pt_PT.xlf
+++ b/src/Resources/translations/NovosgaSettingsBundle.pt_PT.xlf
@@ -116,6 +116,10 @@
         <target>Padrão global</target>
 
       </trans-unit>
+      <trans-unit id="21">
+        <source>settings.user.change_ticket_type</source>
+        <target>Alterar tipo de atendimento</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/views/default/index.html.twig
+++ b/src/Resources/views/default/index.html.twig
@@ -346,6 +346,25 @@
                                                 </select>
                                             </td>
                                         </tr>
+                                        <tr>
+                                            <th>
+                                                {{ 'settings.user.change_ticket_type'|trans }}
+                                            </th>
+                                            <td>
+                                                <select class="form-select" v-model="usuario.behavior.changeTicketType" v-on:change="updateUsuarioBehavior(usuario)">
+                                                    <option :value="null">
+                                                        {{ 'settings.user.use_global'|trans }}
+                                                        ({{ globalBehavior.changeTicketType ? 'label.yes'|trans : 'label.no'|trans }})
+                                                    </option>
+                                                    <option :value="true">
+                                                        {{ 'label.yes'|trans }}
+                                                    </option>
+                                                    <option :value="false">
+                                                        {{ 'label.no'|trans }}
+                                                    </option>
+                                                </select>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>


### PR DESCRIPTION
## Summary

Adds the per-user `changeTicketType` override in the settings module as part of novosga/novosga#460 (main PR: novosga/novosga#494).

- `UpdateUsuarioBehaviorDto`: adds `?bool $changeTicketType`
- `DefaultController`: includes `changeTicketType` in the user behavior data and `UserBehaviorSettings` construction; simplifies JS payload to send the full behavior object
- `index.html.twig`: adds a new row with null/true/false dropdown for `changeTicketType`
- All 6 locale translation files: adds `settings.user.change_ticket_type`

## Test plan

- [ ] Per-user override `false` → that user's type selector is disabled regardless of global setting
- [ ] Per-user override `null` → inherits global `changeTicketType` value (shown in parentheses)
- [ ] Per-user override `true` → type selector enabled regardless of global setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)